### PR TITLE
github action version update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Node
-        uses: actions/setup-node@v2.1.0
+        uses: actions/setup-node@v2.1.2
         with:
           node-version: '12.x'
 


### PR DESCRIPTION
fix security vulnerability : https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/