### PR TITLE
Fixes typo in zbs-operator deployment document

### DIFF
--- a/docs/zbs-operator/deployment.md
+++ b/docs/zbs-operator/deployment.md
@@ -186,7 +186,7 @@ The following provision types are supported:
 
 - `journal`
 - `cache`
-- `paritition`
+- `partition`
 
 [0]: https://docs.openebs.io/docs/next/ndm.html	"OpenEBS NDM"
 


### PR DESCRIPTION
I finally find out why the `partition` cannot be mounted. 🤣 

Maybe we need check the label and throw warning or error in future.