### PR TITLE
docs: supplementary iSCSI configuration steps

### DIFF
--- a/docs/deploy/prerequisites.md
+++ b/docs/deploy/prerequisites.md
@@ -47,7 +47,14 @@ For each Kubernetes worker node that will run IOMesh, follow the following steps
     sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
     ```
 
-4. Start `iscsid` service:
+4. Ensure `iscsi_tcp` kernel module is loaded:
+
+    ```shell
+    sudo modprobe iscsi_tcp
+    sudo bash -c 'echo iscsi_tcp > /etc/modprobe.d/iscsi-tcp.conf'
+    ```
+
+5. Start `iscsid` service:
 
     ```shell
     sudo systemctl enable --now iscsid


### PR DESCRIPTION
部分操作系统发行版由于 iscsi_tcp module 不是默认加载的，导致 open-iscsi 与 IOMesh 连接失败