### PR TITLE
docs: correct metallb install namespace

### DIFF
--- a/docs/advanced-usage/external-iscsi.md
+++ b/docs/advanced-usage/external-iscsi.md
@@ -91,7 +91,7 @@ Since IOMesh runs in a bare metal environment or in other cloud providers that d
 
     ```bash
     helm repo add metallb https://metallb.github.io/metallb
-    helm install metallb metallb/metallb --version 0.12.1
+    helm install metallb metallb/metallb --version 0.12.1 -n iomesh-system
     ```
 
 3. Create a `MetalLB` ConfigMap file called `metallb-config.yaml`, set the work mode of `MetalLB` to layer2 (based on arp), and allocate an IP address pool to `MetalLB`.


### PR DESCRIPTION
之前 external-lun 的文档里安装 metallb 的步骤遗漏了指定 namespace